### PR TITLE
updated unity unit tests scene barriers to measured physical values f…

### DIFF
--- a/digital_twin_unity/Assets/UnitTests/Movement/BACKWARD_100_CM.unity
+++ b/digital_twin_unity/Assets/UnitTests/Movement/BACKWARD_100_CM.unity
@@ -3145,7 +3145,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1443228538}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -3, y: -2.882, z: 11.389999}
+  m_LocalPosition: {x: -3, y: -2.882, z: 11.41}
   m_LocalScale: {x: 2.4678125, y: 0.15594, z: 0.12493}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/digital_twin_unity/Assets/UnitTests/Movement/BACKWARD_10_CM.unity
+++ b/digital_twin_unity/Assets/UnitTests/Movement/BACKWARD_10_CM.unity
@@ -559,7 +559,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1443228538}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -3, y: -2.882, z: 3.89}
+  m_LocalPosition: {x: -3, y: -2.882, z: 2.35}
   m_LocalScale: {x: 2.4678125, y: 0.15594, z: 0.12493}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/digital_twin_unity/Assets/UnitTests/Movement/BACKWARD_25_CM.unity
+++ b/digital_twin_unity/Assets/UnitTests/Movement/BACKWARD_25_CM.unity
@@ -1137,7 +1137,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1443228538}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -3, y: -2.882, z: 3.89}
+  m_LocalPosition: {x: -3, y: -2.882, z: 3.69}
   m_LocalScale: {x: 2.4678125, y: 0.15594, z: 0.12493}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/digital_twin_unity/Assets/UnitTests/Movement/BACKWARD_50_CM.unity
+++ b/digital_twin_unity/Assets/UnitTests/Movement/BACKWARD_50_CM.unity
@@ -2471,7 +2471,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1443228538}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -3, y: -2.882, z: 6.39}
+  m_LocalPosition: {x: -3, y: -2.882, z: 6.3}
   m_LocalScale: {x: 2.4678125, y: 0.15594, z: 0.12493}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/digital_twin_unity/Assets/UnitTests/Movement/FORWARD_100_CM.unity
+++ b/digital_twin_unity/Assets/UnitTests/Movement/FORWARD_100_CM.unity
@@ -502,7 +502,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1443228538}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -3, y: -2.882, z: 11.389999}
+  m_LocalPosition: {x: -3, y: -2.882, z: 11.48}
   m_LocalScale: {x: 2.4678125, y: 0.15594, z: 0.12493}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/digital_twin_unity/Assets/UnitTests/Movement/FORWARD_25_CM.unity
+++ b/digital_twin_unity/Assets/UnitTests/Movement/FORWARD_25_CM.unity
@@ -559,7 +559,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1443228538}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -3, y: -2.882, z: 3.89}
+  m_LocalPosition: {x: -3, y: -2.882, z: 3.84}
   m_LocalScale: {x: 2.4678125, y: 0.15594, z: 0.12493}
   m_ConstrainProportionsScale: 0
   m_Children: []


### PR DESCRIPTION
- Changed distances between start and end barriers for unity distance tests to match the average of the physical calibration tests that were performed with the rover. 